### PR TITLE
Commenting out generic exception handler code

### DIFF
--- a/node_updater.py
+++ b/node_updater.py
@@ -119,11 +119,11 @@ def run():
             print 'Timeout on Node Comms'
             post_to_slack(":no_entry_sign: %s - Timeout while trying to communicate with Node." % linkit(node))
 
-        except Exception, e:
-            print 'Exception on Node Comms'
-            print e
-            post_to_slack(":feelsgood: %s - Exception while trying to communicate with Node.\n"
-                          "Exception: %s" % (linkit(node), e))
+        # except Exception, e:
+        #     print 'Exception on Node Comms'
+        #     print e
+        #     post_to_slack(":feelsgood: %s - Exception while trying to communicate with Node.\n"
+        #                   "Exception: %s" % (linkit(node), e))
 
         # Turn off our timeout.
         signal.alarm(0)


### PR DESCRIPTION
@smn @bruskiza  - This should do two things:
1. Identify exactly where the issue is by logging the right error.
2. Restart the entire process so our "connection already closed" issue goes away.

We'll have to add in additional catches for the exceptions that come up regularly.
